### PR TITLE
chore: allow durationInMinutes in Support Profile

### DIFF
--- a/python/idsse/testing/nwsc_gateway/support_profile_gsl_test_3.json
+++ b/python/idsse/testing/nwsc_gateway/support_profile_gsl_test_3.json
@@ -32,7 +32,7 @@
         ],
         "timing": {
           "start": null,
-          "duration": 0,
+          "durationInMinutes": 0,
           "rrule": ""
         },
         "nationalSecurity": false,

--- a/python/idsse/testing/nwsc_gateway/support_profile_single_point.json
+++ b/python/idsse/testing/nwsc_gateway/support_profile_single_point.json
@@ -32,7 +32,7 @@
         ],
         "timing": {
           "start": null,
-          "duration": 0,
+          "durationInMinutes": 0,
           "rrule": ""
         },
         "nationalSecurity": false,

--- a/python/nwsc_proxy/src/profile_store.py
+++ b/python/nwsc_proxy/src/profile_store.py
@@ -19,8 +19,6 @@ from math import inf
 
 from dateutil.parser import parse as dt_parse
 
-datetime.max
-
 # constants controlling the subdirectory where new vs. existing Profiles are saved
 NEW_SUBDIR = "new"
 EXISTING_SUBDIR = "existing"

--- a/python/nwsc_proxy/src/profile_store.py
+++ b/python/nwsc_proxy/src/profile_store.py
@@ -19,6 +19,8 @@ from math import inf
 
 from dateutil.parser import parse as dt_parse
 
+datetime.max
+
 # constants controlling the subdirectory where new vs. existing Profiles are saved
 NEW_SUBDIR = "new"
 EXISTING_SUBDIR = "existing"
@@ -61,20 +63,22 @@ class CachedProfile:
     @property
     def start_timestamp(self) -> float:
         """The Support Profile event's start in Unix time (milliseconds since the epoch).
-        -1 if Support Profile is never-ending
+        math.inf if Support Profile is never-ending
         """
-        profile_start = self.data["setting"]["timing"].get("start")
-        return dt_parse(profile_start).timestamp() if profile_start else -1
+        profile_start: str | None = self.data["setting"]["timing"].get("start")
+        return dt_parse(profile_start).timestamp() if profile_start else inf
 
     @property
     def end_timestamp(self) -> float:
         """The Support Profile event's end in Unix time (milliseconds since the epoch).
         math.inf if Support Profile is never-ending
         """
-        if self.start_timestamp < 0:
+        if self.start_timestamp == inf:
             return inf  # infinite start time, so infinite end time as well
-        profile_duration = self.data["setting"]["timing"].get("duration", 0)
-        return self.start_timestamp + profile_duration * 60 * 1000  # convert min to ms
+        timing: dict[str, int] = self.data["setting"]["timing"]
+        # look up durationInMinutes, or deprecated duration, or None
+        profile_duration = timing.get("durationInMinutes", timing.get("duration", inf))
+        return self.start_timestamp + profile_duration * 60 * 1000  # convert mins to ms
 
     @property
     def data_sources(self) -> list[str]:
@@ -200,13 +204,13 @@ class ProfileStore:
         # save Profile JSON to filesystem
         file_dir = self._new_dir if is_new else self._existing_dir
         filepath = os.path.join(file_dir, f"{cached_profile.id}.json")
-        logger.warning("Now saving profile to path: %s", filepath)
+        logger.debug("Now saving profile to path: %s", filepath)
         with open(filepath, "w", encoding="utf-8") as file:
             json.dump(profile, file)
 
         # add profile to in-memory cache
         self.profile_cache.append(cached_profile)
-        logger.warning("Saved profile to cache, file locationh: %s", filepath)
+        logger.info("Saved profile to cache, file location: %s", filepath)
         return cached_profile.id
 
     def mark_as_existing(self, profile_id: str) -> bool:

--- a/python/nwsc_proxy/src/profiles/nwsc_test_response_1.json
+++ b/python/nwsc_proxy/src/profiles/nwsc_test_response_1.json
@@ -32,7 +32,7 @@
         ],
         "timing": {
           "start": null,
-          "duration": 0,
+          "durationInMinutes": 0,
           "rrule": ""
         },
         "nationalSecurity": false,

--- a/python/nwsc_proxy/src/profiles/nwsc_test_response_2.json
+++ b/python/nwsc_proxy/src/profiles/nwsc_test_response_2.json
@@ -32,7 +32,7 @@
         ],
         "timing": {
           "start": null,
-          "duration": 0,
+          "durationInMinutes": 0,
           "rrule": ""
         },
         "nationalSecurity": false,

--- a/python/nwsc_proxy/src/profiles/nwsc_test_response_3.json
+++ b/python/nwsc_proxy/src/profiles/nwsc_test_response_3.json
@@ -32,7 +32,7 @@
         ],
         "timing": {
           "start": null,
-          "duration": 0,
+          "durationInMinutes": 0,
           "rrule": ""
         },
         "nationalSecurity": false,


### PR DESCRIPTION
~_Note: this PR will break the dev environment unless [NWSC Gateway PR #13](https://github.com/NOAA-GSL/nwsc-gateway/pull/13) is merged first_~ <-- merged

### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
N/A

### Changes
<!-- Brief description of changes -->
- Expect `durationInMinutes` integer field in "timing" of Support Profile jsons
  - Less ambiguous than the previous `duration` value. Will fallback to extracting `duration` if any profiles still use it field
- Update all test profiles (GSL Test 1, 2, 3) to use `durationInMinutes` from here on out 


### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
N/A