### PR TITLE
chore: protect against invalid PATCHes

### DIFF
--- a/python/nwsc_proxy/ncp_web_service.py
+++ b/python/nwsc_proxy/ncp_web_service.py
@@ -117,6 +117,9 @@ class EventsRoute:
         return jsonify({"message": f"Profile {profile_id} saved"}), 201
 
     def _handle_update(self) -> Response:
+        if not request.data:
+            return jsonify({"message": "PATCH requires request body"}), 400
+
         request_body: dict = request.json
         profile_id = request.args.get("id", request.args.get("uuid"))
 

--- a/python/nwsc_proxy/ncp_web_service.py
+++ b/python/nwsc_proxy/ncp_web_service.py
@@ -87,7 +87,7 @@ class EventsRoute:
     def _handle_delete(self) -> Response:
         """Logic for DELETE requests to /all-events. Returns Response with status_code: 204 on
         success, 404 otherwise."""
-        profile_id = request.args.get("uuid")
+        profile_id = request.args.get("id", request.args.get("uuid"))
         is_deleted = self.profile_store.delete(profile_id)
         if not is_deleted:
             return jsonify({"message": f"Profile {profile_id} not found"}), 404
@@ -118,10 +118,10 @@ class EventsRoute:
 
     def _handle_update(self) -> Response:
         request_body: dict = request.json
-        profile_id = request.args.get("uuid")
+        profile_id = request.args.get("id", request.args.get("uuid"))
 
         if not profile_id:
-            return jsonify({"message": "Missing required query parameter: uuid"}), 400
+            return jsonify({"message": "Missing required query parameter: id"}), 400
 
         try:
             updated_profile = self.profile_store.update(profile_id, request_body)

--- a/python/nwsc_proxy/src/profile_store.py
+++ b/python/nwsc_proxy/src/profile_store.py
@@ -246,7 +246,7 @@ class ProfileStore:
         return True
 
     def update(self, profile_id: str, data: dict) -> dict:
-        """Update a Support Profile in storage based on its UUID.
+        """Update a Support Profile in storage based on its id.
 
         Args:
             profile_id (str): The UUID of the Support Profile to update
@@ -256,7 +256,7 @@ class ProfileStore:
             dict: the latest version of the Profile, with all attribute changes applied
 
         Raises:
-            FileNotFoundError: if no Support Profile exists with the provided uuid
+            FileNotFoundError: if no Support Profile exists with the provided id
         """
         logger.info("Updating profile_id %s with new attributes: %s", profile_id, data)
 

--- a/python/nwsc_proxy/test/test_ncp_web_service.py
+++ b/python/nwsc_proxy/test/test_ncp_web_service.py
@@ -213,7 +213,7 @@ def test_create_previous_profile_failure(
 
 def test_delete_profile_success(wrapper: AppWrapper, mock_request: Mock, mock_profile_store: Mock):
     mock_request.method = "DELETE"
-    mock_request.args = MultiDict({"uuid": EXAMPLE_UUID})
+    mock_request.args = MultiDict({"id": EXAMPLE_UUID})
     mock_profile_store.return_value.delete.return_value = True  # delete worked
 
     result: tuple[Response, int] = wrapper.app.view_functions["events"]()
@@ -234,7 +234,7 @@ def test_delete_profile_failure(wrapper: AppWrapper, mock_request: Mock, mock_pr
 
 def test_update_profile_success(wrapper: AppWrapper, mock_request: Mock, mock_profile_store: Mock):
     mock_request.method = "PATCH"
-    mock_request.args = MultiDict({"uuid": EXAMPLE_UUID})
+    mock_request.args = MultiDict({"id": EXAMPLE_UUID})
     mock_request.json = {"name": "Some new name"}
     updated_profile = {"id": EXAMPLE_UUID, "name": "Some new name"}
 

--- a/python/nwsc_proxy/test/test_ncp_web_service.py
+++ b/python/nwsc_proxy/test/test_ncp_web_service.py
@@ -245,6 +245,16 @@ def test_update_profile_success(wrapper: AppWrapper, mock_request: Mock, mock_pr
     assert result[0].json["profile"] == updated_profile
 
 
+def test_update_no_body(wrapper: AppWrapper, mock_request: Mock, mock_profile_store: Mock):
+    mock_request.method = "PATCH"
+    mock_request.args = MultiDict({"uuid": EXAMPLE_UUID})
+    mock_request.data = None
+
+    result: tuple[Response, int] = wrapper.app.view_functions["events"]()
+
+    assert result[1] == 400
+
+
 def test_update_profile_missing(wrapper: AppWrapper, mock_request: Mock, mock_profile_store: Mock):
     mock_request.method = "PATCH"
     mock_request.args = MultiDict({"uuid": EXAMPLE_UUID})


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
N/A

### Changes
<!-- Brief description of changes -->
- Minor code protection against PATCH of existing profile with empty body
  - Shouldn't be a problem, but I spent an entire day debugging on the Criteria Builder side because it was accidentally sending PATCH with an empty request `body`. NWSC Proxy just hung forever trying to de-serialize the "JSON" of an empty body, rather than promptly sending back a 400.
- Add support for DELETE/PATCH requests with `id` for Profile id, rather than `uuid`. 
  - Support Profile uses "id" more often than UUID, so it was inconsistent API spec

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
N/A