### PR TITLE
feat: support "includeInactive" query param

### DIFF
--- a/python/nwsc_proxy/ncp_web_service.py
+++ b/python/nwsc_proxy/ncp_web_service.py
@@ -64,11 +64,18 @@ class EventsRoute:
         # otherwise, must be 'GET' operation
         data_source = request.args.get("dataSource", None, type=str)
         profile_status = request.args.get("status", default="existing", type=str)
+
+        # let request control if `isLive: false` profiles are included in response.
+        # Default to False if param not present (only return profiles where isLive: true)
+        include_inactive = request.args.get("includeInactive", default=False, type=bool)
+
         if profile_status == "existing":
-            profiles = self.profile_store.get_all(data_source)
+            profiles = self.profile_store.get_all(data_source, include_inactive=include_inactive)
 
         elif profile_status == "new":
-            profiles = self.profile_store.get_all(data_source, is_new=True)
+            profiles = self.profile_store.get_all(
+                data_source, is_new=True, include_inactive=include_inactive
+            )
             # update ProfileStore to label all queried events as no longer "new";
             # they've now been returned to IDSS Engine clients at least once
             current_app.logger.info("Got all new profiles: %s", profiles)

--- a/python/nwsc_proxy/src/profile_store.py
+++ b/python/nwsc_proxy/src/profile_store.py
@@ -141,7 +141,7 @@ class ProfileStore:
 
         self.profile_cache = existing_profiles + new_profiles
 
-    def get_all(self, data_source="ANY", is_new=False) -> list[dict]:
+    def get_all(self, data_source="ANY", is_new=False, include_inactive=False) -> list[dict]:
         """Get all Support Profile JSONs persisted in this API, filtering by status='new'
         (if Support Profile has never been returned in an API request before) or status='existing'
         otherwise.
@@ -158,7 +158,7 @@ class ProfileStore:
                 # is new, if client requested new profiles, or is existing
                 cached_profile.is_new == is_new
                 # is "active", meaning no one has intentional disabled/deactivated it
-                and cached_profile.is_active
+                and (include_inactive or cached_profile.is_active)
                 # the end_dt has not yet passed (or profile is never-ending)
                 and datetime.now(UTC).timestamp() <= cached_profile.end_timestamp
             )

--- a/python/nwsc_proxy/test/test_ncp_web_service.py
+++ b/python/nwsc_proxy/test/test_ncp_web_service.py
@@ -137,7 +137,7 @@ def test_get_existing_profiles(wrapper: AppWrapper, mock_request: Mock, mock_pro
     assert status_code == 200
     assert response.json == {"profiles": example_profile_list, "errors": []}
     # filter_new_profiles not set
-    mock_profile_store.return_value.get_all.assert_called_with("NBM")
+    mock_profile_store.return_value.get_all.assert_called_with("NBM", include_inactive=False)
 
 
 def test_get_new_profiles(wrapper: AppWrapper, mock_request: Mock, mock_profile_store: Mock):
@@ -153,7 +153,7 @@ def test_get_new_profiles(wrapper: AppWrapper, mock_request: Mock, mock_profile_
 
     get_call_args = mock_profile_store.return_value.get_all.mock_calls
     # called with is_new set to True
-    assert get_call_args[0][1:] == (("NBM",), {"is_new": True})
+    assert get_call_args[0][1:] == (("NBM",), {"is_new": True, "include_inactive": False})
 
     # expect that we told ProfileStore to label this profile as not new
     mark_existing_call_args = mock_profile_store.return_value.mark_as_existing.mock_calls


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
N/A

### Changes
<!-- Brief description of changes -->
- NWSC Proxy API: support optional query param `includeInactive` on GET requests
  - If `includeInactive` query param included, NWSC Proxy returns profiles whether or not they have `isLive: false` in their JSON
  - Default is False (unchanged behavior from before)

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
These changes let us "turn off" a profile from future IDSSE processing without permanently deleting the profile and all its data. Previously we had to nuke any Profile in the Proxy, erasing all history, if we wanted to stop it from generating Event Portfolios.

By default, the NWSC Gateway (which feeds Risk Processor) will continue to only see Support Profiles in the NWSC Proxy that have `isLive: false`. However, the NOAA UI a.k.a. Criteria Builder needs a way to query _all_ existing Profiles, so users can see deactivated Profiles and reactivate them if needed.
