### PR TITLE
fix: NWSC Proxy accept `officeId` param

### DIFF
--- a/python/nwsc_proxy/README.md
+++ b/python/nwsc_proxy/README.md
@@ -79,7 +79,24 @@ python3 ncp_web_service.py --base_dir /path/to/some/dir
 On startup, the service creates 'existing' and 'new' subdirectories at the path location given by `--base_dir` if needed, then reads into its in-memory cache any existing JSON files in the base directory or either subdirectory.
 
 ### Endpoints
+The following endpoints should roughly match the [NWS Connect Parter Vulnerabilities API spec](https://vlab.noaa.gov/gitlab-licensed/NWS/Operations/STI/MDL/nwsconnect/foundation-api/api-fndn/-/blob/develop/documentation/PartnerVulnerabilitiesOpenAPI.yaml)
+
 - GET `/health`
+- GET `/vulnerabililities?officeId=SFO`
+  - Get list of existing Partner Vulnerabilities, optionally filtered by Vulnerabilities associated with a specific NWS office (e.g. BOU, SFO, etc.)
+- POST `/vulnerabilities`
+  - Create a new Partner Vulnerability to be stored by the API. `id` property from the client will be ignored--the API generates a unique ID on the fly and includes it in the response body. 
+  - Very minimal validation of the request body is completed; don't expect it to enforce anything other than the existence of `id`, `name`, `primaryOfficeId`, and `hazards`. This isn't a real database.
+- GET `/vulnerabilities/:id/`
+  - Get a specific Partner Vulnerability object, by id. 404 if id does not exist.
+- PATCH `/vulnerabilities/:id`
+  - Update an existing Vulnerability (partial update, adhering to the "JSON merge patch" standard). Returns `404` if no Vulnerability stored in the API matches the `id` provided
+- DELETE `/vulnerabilities/:id`
+  - Permanently delete a Vulnerability from the API. 
+
+#### Legacy endpoints
+The following endpoints rely on an outdated object model ("Support Profile") from 2023. They will be removed no earlier than Sept 2026.
+
 - GET `/all-events?dataSource=ANY&status=existing`
   - Get list of existing Support Profiles (not new). Will be formatted like `{ "profiles": [], "errors": []}`
 - GET `/all-events?dataSource=ANY&status=new`
@@ -91,4 +108,4 @@ On startup, the service creates 'existing' and 'new' subdirectories at the path 
 - DELETE `/all-events?uuid=<some id>`
   - Permanently remove an existing Support Profile from the API. `uuid` must match one of the saved Support Profile JSON's `id` attribute, otherwise it will return `404`.
 
-Note that all requests to the `/all-events` endpoint require an `X-Api-Key` header that must match the approved key, or the API will return `401`.
+Note that all requests to the `/all-events` and `/vulnerabilities` endpoints require an `X-Api-Key` header that must match the approved key, or the API will return `401`.

--- a/python/nwsc_proxy/ncp_web_service.py
+++ b/python/nwsc_proxy/ncp_web_service.py
@@ -65,15 +65,16 @@ class VulnerabilitiesRoute:
             return self._handle_create()
 
         # otherwise, must be 'GET' operation
+        office = request.args.get("officeId")
 
         # let request control if `isDeleted: true` profiles are included in response.
         # Default to False if param not present (only return profiles where isDeleted: false)
         include_is_deleted = request.args.get("isDeleted", default=False, type=bool)
 
-        profiles = self._profile_store.get_all(include_inactive=include_is_deleted)
+        profiles = self._profile_store.get_all(include_inactive=include_is_deleted, office=office)
         return jsonify(profiles), 200
 
-    def document(self, profile_id):
+    def document(self, profile_id: str):
         """Logic for HTTP requests to /vulnerabilities/:profile_id"""
 
         # pylint: disable=duplicate-code

--- a/python/nwsc_proxy/src/vulnerability_store.py
+++ b/python/nwsc_proxy/src/vulnerability_store.py
@@ -169,7 +169,9 @@ class VulnerabilityStore:
             for profile in self._load_profiles_from_filesystem(self._profile_dir)
         }
 
-    def get_all(self, data_source="ANY", include_inactive=False) -> list[dict]:
+    def get_all(
+        self, data_source="ANY", include_inactive=False, office: str | None = None
+    ) -> list[dict]:
         """Get all Profile JSONs persisted in this API.
 
         Args:
@@ -177,6 +179,8 @@ class VulnerabilityStore:
                 (return all discovered Profiles).
             include_inactive (optional, bool): if True, return all Profiles, even those marked as
                 `isDeleted: False`. Defaults to False (hide deleted profiles).
+            office (optional, str): the NWS office ID to filter Profiles, e.g. "BOU" or "SFO".
+                Not case sensitive. Defaults to None (return Profiles associated with any office).
         """
         # compare all Profiles to the same now() value
         current_timestamp = datetime.now(UTC).timestamp()
@@ -187,6 +191,8 @@ class VulnerabilityStore:
             if (include_inactive or not cached_profile.is_deleted)
             # the end_dt has not yet passed (or profile is never-ending)
             and current_timestamp <= cached_profile.end_timestamp
+            # is associated with requested office (or no office specified)
+            and (not office or office.upper().strip() == cached_profile.office.upper())
         ]
 
         if data_source == "ANY":

--- a/python/nwsc_proxy/test/test_ncp_web_service.py
+++ b/python/nwsc_proxy/test/test_ncp_web_service.py
@@ -13,6 +13,7 @@
 import json
 from datetime import timedelta
 from unittest.mock import Mock
+from uuid import uuid4
 
 from flask import Request, Response
 from pytest import fixture, MonkeyPatch
@@ -232,6 +233,20 @@ def test_get_vulnerabilities(wrapper: AppWrapper, mock_store: Mock, mock_sp_stor
     assert actual_profile_list[0]["id"] == EXAMPLE_UUID
     mock_store.return_value.get_all.assert_called_once()
     mock_sp_store.return_value.get_all.assert_not_called()
+
+
+def test_get_vulnerabilities_office(wrapper: AppWrapper, mock_store: Mock, mock_request: Mock):
+    expected_office = "BOU"
+    example_profile_list = [{"id": EXAMPLE_UUID, "name": "My Profile", "primaryOfficeId": "BOU"}]
+    mock_store.return_value.get_all.return_value = example_profile_list
+    mock_request.args = MultiDict({"officeId": expected_office})
+
+    result: tuple[Response, int] = wrapper.app.view_functions["vulnerabilities"]()
+
+    assert result[1] == 200
+    mock_store.return_value.get_all.assert_called_once_with(
+        include_inactive=False, office=expected_office
+    )
 
 
 def test_post_vulnerabilities(wrapper: AppWrapper, mock_store: Mock, mock_request: Mock):

--- a/python/nwsc_proxy/test/test_ncp_web_service.py
+++ b/python/nwsc_proxy/test/test_ncp_web_service.py
@@ -13,7 +13,6 @@
 import json
 from datetime import timedelta
 from unittest.mock import Mock
-from uuid import uuid4
 
 from flask import Request, Response
 from pytest import fixture, MonkeyPatch

--- a/python/nwsc_proxy/test/test_vulnerability_store.py
+++ b/python/nwsc_proxy/test/test_vulnerability_store.py
@@ -80,6 +80,27 @@ def test_get_all_profiles(store: VulnerabilityStore):
     assert len(result) == 3
 
 
+def test_get_profiles_by_office(store: VulnerabilityStore, mock_uuid: Mock):
+    expected_office = "SFO"
+    ignored_profile = EXAMPLE_PROFILE
+    expected_profile = deepcopy(EXAMPLE_PROFILE)
+    expected_profile["primaryOfficeId"] = expected_office
+    expected_profile["name"] = "Some SFO Profile"
+    # hack save() to return our new profile's ID when uuid() is called, and save Profile to Store
+    expected_profile["id"] = str(uuid4())
+    mock_uuid.return_value = UUID(expected_profile["id"])
+    store.save(expected_profile)
+
+    # office is case insensitive
+    actual_profiles = store.get_all(office=expected_office.lower())
+
+    # "My Profile" was filtered out due to mismatching Office, only "Your Profile" came back
+    actual_ids = [p["id"] for p in actual_profiles]
+    assert expected_profile["id"] in actual_ids
+    assert ignored_profile["id"] not in actual_ids
+    assert all(p["primaryOfficeId"] == expected_office for p in actual_profiles)
+
+
 def test_skips_expired_profile(store: VulnerabilityStore, mock_uuid: Mock):
     expected_id = str(uuid4())
     mock_uuid.return_value = expected_id
@@ -92,10 +113,11 @@ def test_skips_expired_profile(store: VulnerabilityStore, mock_uuid: Mock):
     # actually commit expired Profile to store
     store.save(new_profile)
 
-    actual_profile_list = [p["id"] for p in store.get_all()]
+    actual_profiles = store.get_all()
 
     # get_all() ignores profile that has already ended
-    assert expected_id not in actual_profile_list
+    actual_profile_ids = [p["id"] for p in actual_profiles]
+    assert expected_id not in actual_profile_ids
 
 
 def test_get_one_profile(store: VulnerabilityStore):


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-166](https://linear.app/idss/issue/IDSSE-166)

### Changes
<!-- Brief description of changes -->
- fix: NWSC Proxy `/vulnerabilities` endpoint accept query param `?officeId=<some office>`, defaulting to no office filter

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
This filtering was included to align with NWS Connect Vulnerabilities API spec, so the DSD can seamlessly communicate with our API or the real NWS Connect API.