### PR TITLE
feat: Proxy: /session/logout endpoint

### DIFF
--- a/python/nwsc_proxy/ncp_web_service.py
+++ b/python/nwsc_proxy/ncp_web_service.py
@@ -79,6 +79,17 @@ class AuthenticationRoute:
         )
         return jsonify(updated_user), 200
 
+    def logout(self):
+        """Logout a logged-in user (simulated NOAA SSO behavior)"""
+        cookie_header: str = request.headers.get("Cookie", "")
+        # parse cookie header to extract JSESSIONID, if it exists
+        cookies = self._read_cookies(cookie_header)
+        session_id = cookies.get("JSESSIONID")
+
+        # ignore return from store; we don't care about failures because nothing is real
+        self._user_store.delete_user(session_id)
+        return {}, 200
+
     def _read_cookies(self, cookie_header: str) -> dict[str, str]:
         if cookie_header == "":
             return {}  # empty string, no cookies, nothing to do
@@ -194,6 +205,9 @@ class AppWrapper:
             "user",
             view_func=auth_route.user,
             methods=["GET", "PATCH"],
+        )
+        self.app.add_url_rule(
+            f"{base_url}/session/logout", "logout", view_func=auth_route.logout, methods=["POST"]
         )
         self.app.add_url_rule(
             f"{base_url}/vulnerabilities",

--- a/python/nwsc_proxy/src/user_store.py
+++ b/python/nwsc_proxy/src/user_store.py
@@ -59,6 +59,15 @@ class UserStore:
         session = self._create_session(session_id)
         return session.data
 
+    def delete_user(self, session_id: str | None) -> bool:
+        """Delete a user's settings session, if one exists.
+
+        Returns:
+            bool: True if session was found and deleted
+        """
+        existing_session = self._sessions.pop(session_id, None)
+        return existing_session is not None
+
     def update_user_settings(
         self, session_id: str, active_office: str | None = None, settings: dict | None = None
     ):

--- a/python/nwsc_proxy/test/test_ncp_web_service.py
+++ b/python/nwsc_proxy/test/test_ncp_web_service.py
@@ -100,7 +100,7 @@ def wrapper(mock_store, mock_user_store, mock_datetime, mock_request) -> AppWrap
 def test_create_app(mock_store):
     args = Namespace()
     args.base_dir = "/fake/base/dir"
-    expected_endpoints = ["health", "token", "user", "vulnerabilities", "vulnerability"]
+    expected_endpoints = ["health", "logout", "token", "user", "vulnerabilities", "vulnerability"]
 
     _app = create_app(args)
 


### PR DESCRIPTION
### Linear Issue
<!-- Replace both "IDSSE-xxx" strings below with your Issue, e.g. "IDSSE-123" -->
[IDSSE-7](https://linear.app/idss/issue/IDSSE-7)

### Changes
<!-- Brief description of changes -->
- feat: NWSC Proxy: add `/session/logout` endpoint to simulate NWS Connect user logout actions

### Explanation
<!-- Include any discussion, if needed, such as why these changes were needed or why a certain implementation was chosen -->
N/A